### PR TITLE
Add driver card workflow page

### DIFF
--- a/src/api/driverCards.js
+++ b/src/api/driverCards.js
@@ -1,0 +1,5 @@
+import API from './api'
+
+export const getDriverCards = () => API.get('/driverCards')
+export const addDriverCard = (payload) => API.post('/driverCards', payload)
+export const updateDriverCard = (id, payload) => API.put(`/driverCards/${id}`, payload)

--- a/src/api/drivers.js
+++ b/src/api/drivers.js
@@ -1,0 +1,4 @@
+import API from './api'
+
+export const getDrivers = () => API.get('/drivers')
+export const addDriver = (payload) => API.post('/drivers', payload)

--- a/src/api/facilities.js
+++ b/src/api/facilities.js
@@ -1,0 +1,4 @@
+import API from './api'
+
+export const getFacilities = () => API.get('/facilities')
+export const addFacility = (payload) => API.post('/facilities', payload)

--- a/src/menuAside.js
+++ b/src/menuAside.js
@@ -35,6 +35,11 @@ export default [
     icon: mdiTable,
   },
   {
+    to: '/driver-card-workflow',
+    label: 'Driver Cards',
+    icon: mdiTable,
+  },
+  {
     to: '/ui',
     label: 'UI',
     icon: mdiTelevisionGuide,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -47,6 +47,14 @@ const routes = [
   },
   {
     meta: {
+      title: 'Driver Card Workflow',
+    },
+    path: '/driver-card-workflow',
+    name: 'driver-card-workflow',
+    component: () => import('@/views/DriverCardWorkflow.vue'),
+  },
+  {
+    meta: {
       title: 'Profile',
     },
     path: '/profile',

--- a/src/stores/driverCardWorkflow.js
+++ b/src/stores/driverCardWorkflow.js
@@ -1,0 +1,65 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { getFacilities, addFacility } from '@/api/facilities'
+import { getDrivers, addDriver } from '@/api/drivers'
+import { getDriverCards, addDriverCard, updateDriverCard } from '@/api/driverCards'
+
+export const useDriverCardWorkflowStore = defineStore('driverCardWorkflow', () => {
+  const facility = ref(null)
+  const driver = ref(null)
+  const card = ref(null)
+
+  async function findFacility(identity) {
+    const { data } = await getFacilities()
+    facility.value = data.find((f) => f.IdentityNumber === identity) || null
+    return facility.value
+  }
+
+  async function createFacility(payload) {
+    const { data } = await addFacility(payload)
+    facility.value = data
+    return facility.value
+  }
+
+  async function findDriver(identity) {
+    const { data } = await getDrivers()
+    driver.value = data.find((d) => d.IdentityNumber === identity) || null
+    return driver.value
+  }
+
+  async function createDriver(payload) {
+    const { data } = await addDriver(payload)
+    driver.value = data
+    return driver.value
+  }
+
+  async function findDriverCard() {
+    if (!driver.value) return null
+    const { data } = await getDriverCards()
+    card.value = data.find((c) => c.DriverID === driver.value.DriverID) || null
+    return card.value
+  }
+
+  async function saveCard(payload) {
+    if (card.value) {
+      const { data } = await updateDriverCard(card.value.ID, payload)
+      card.value = data
+    } else {
+      const { data } = await addDriverCard(payload)
+      card.value = data
+    }
+    return card.value
+  }
+
+  return {
+    facility,
+    driver,
+    card,
+    findFacility,
+    createFacility,
+    findDriver,
+    createDriver,
+    findDriverCard,
+    saveCard,
+  }
+})

--- a/src/views/DriverCardWorkflow.vue
+++ b/src/views/DriverCardWorkflow.vue
@@ -1,0 +1,174 @@
+<script setup>
+import { ref } from 'vue'
+import { mdiIdCard, mdiDomain, mdiAccount } from '@mdi/js'
+import LayoutAuthenticated from '@/layouts/LayoutAuthenticated.vue'
+import SectionMain from '@/components/SectionMain.vue'
+import SectionTitleLineWithButton from '@/components/SectionTitleLineWithButton.vue'
+import CardBox from '@/components/CardBox.vue'
+import FormField from '@/components/FormField.vue'
+import FormControl from '@/components/FormControl.vue'
+import BaseButtons from '@/components/BaseButtons.vue'
+import BaseButton from '@/components/BaseButton.vue'
+import CardBoxModal from '@/components/CardBoxModal.vue'
+import { useDriverCardWorkflowStore } from '@/stores/driverCardWorkflow'
+
+const store = useDriverCardWorkflowStore()
+
+const facilityIdInput = ref('')
+const driverIdInput = ref('')
+
+const modalFacility = ref(false)
+const modalDriver = ref(false)
+
+const newFacility = ref({ IdentityNumber: '', Name: '' })
+const newDriver = ref({ FirstName: '', LastName: '', IdentityNumber: '', FacilityID: '' })
+
+const cardForm = ref({
+  CardNumber: '',
+  CardType: '',
+  FacilityID: '',
+  DriverID: '',
+  IssueDate: '',
+  ExpirationDate: '',
+  Supplier: '',
+  addingDate: '',
+  LastUpdate: '',
+  userID: '',
+})
+
+async function checkFacility() {
+  await store.findFacility(facilityIdInput.value)
+  if (!store.facility) {
+    newFacility.value.IdentityNumber = facilityIdInput.value
+    modalFacility.value = true
+  }
+}
+
+async function confirmFacility() {
+  await store.createFacility(newFacility.value)
+  modalFacility.value = false
+}
+
+async function checkDriver() {
+  await store.findDriver(driverIdInput.value)
+  if (!store.driver) {
+    newDriver.value.IdentityNumber = driverIdInput.value
+    newDriver.value.FacilityID = store.facility?.FacilityID || ''
+    modalDriver.value = true
+  } else {
+    await store.findDriverCard()
+    populateCard()
+  }
+}
+
+async function confirmDriver() {
+  await store.createDriver(newDriver.value)
+  modalDriver.value = false
+  await store.findDriverCard()
+  populateCard()
+}
+
+function populateCard() {
+  cardForm.value = {
+    CardNumber: store.card?.CardNumber || '',
+    CardType: store.card?.CardType || '',
+    FacilityID: store.facility?.FacilityID || '',
+    DriverID: store.driver?.DriverID || '',
+    IssueDate: store.card?.IssueDate || '',
+    ExpirationDate: store.card?.ExpirationDate || '',
+    Supplier: store.card?.Supplier || '',
+    addingDate: store.card?.addingDate || '',
+    LastUpdate: store.card?.LastUpdate || '',
+    userID: store.card?.userID || '',
+  }
+}
+
+async function saveCard() {
+  cardForm.value.FacilityID = store.facility?.FacilityID || ''
+  cardForm.value.DriverID = store.driver?.DriverID || ''
+  await store.saveCard(cardForm.value)
+}
+</script>
+
+<template>
+  <LayoutAuthenticated>
+    <SectionMain>
+      <SectionTitleLineWithButton :icon="mdiIdCard" title="Driver Card Workflow" main />
+
+      <CardBox class="mb-6" is-form @submit.prevent="checkFacility">
+        <FormField label="Facility Identity">
+          <FormControl v-model="facilityIdInput" :icon="mdiDomain" />
+        </FormField>
+        <template #footer>
+          <BaseButtons>
+            <BaseButton type="submit" color="info" label="Next" />
+          </BaseButtons>
+        </template>
+      </CardBox>
+
+      <CardBox v-if="store.facility" class="mb-6" is-form @submit.prevent="checkDriver">
+        <FormField label="Driver Identity">
+          <FormControl v-model="driverIdInput" :icon="mdiAccount" />
+        </FormField>
+        <template #footer>
+          <BaseButtons>
+            <BaseButton type="submit" color="info" label="Next" />
+          </BaseButtons>
+        </template>
+      </CardBox>
+
+      <CardBox v-if="store.driver" class="mb-6" is-form @submit.prevent="saveCard">
+        <FormField label="Card Number">
+          <FormControl v-model="cardForm.CardNumber" />
+        </FormField>
+        <FormField label="Card Type">
+          <FormControl v-model="cardForm.CardType" />
+        </FormField>
+        <FormField label="Issue Date">
+          <FormControl v-model="cardForm.IssueDate" type="date" />
+        </FormField>
+        <FormField label="Expiration Date">
+          <FormControl v-model="cardForm.ExpirationDate" type="date" />
+        </FormField>
+        <template #footer>
+          <BaseButtons>
+            <BaseButton type="submit" color="success" label="Save" />
+          </BaseButtons>
+        </template>
+      </CardBox>
+    </SectionMain>
+
+    <CardBoxModal
+      v-model="modalFacility"
+      title="Create Facility"
+      button-label="Save"
+      has-cancel
+      @confirm="confirmFacility"
+    >
+      <FormField label="Identity Number">
+        <FormControl v-model="newFacility.IdentityNumber" />
+      </FormField>
+      <FormField label="Name">
+        <FormControl v-model="newFacility.Name" />
+      </FormField>
+    </CardBoxModal>
+
+    <CardBoxModal
+      v-model="modalDriver"
+      title="Create Driver"
+      button-label="Save"
+      has-cancel
+      @confirm="confirmDriver"
+    >
+      <FormField label="First Name">
+        <FormControl v-model="newDriver.FirstName" />
+      </FormField>
+      <FormField label="Last Name">
+        <FormControl v-model="newDriver.LastName" />
+      </FormField>
+      <FormField label="Identity Number">
+        <FormControl v-model="newDriver.IdentityNumber" />
+      </FormField>
+    </CardBoxModal>
+  </LayoutAuthenticated>
+</template>


### PR DESCRIPTION
## Summary
- add API helpers for facilities, drivers, and driver cards
- manage workflow state with new Pinia store
- implement DriverCardWorkflow.vue to guide users through facility, driver and card setup
- register the new page in router and aside menu

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883c4ca9f988331b4878f49ca3739aa