### PR TITLE
Fix i18n legacy mode error

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
 import { RouterView } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 
-const { locale } = useI18n()
+useI18n()
 </script>
 
 <template>

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -80,6 +80,7 @@ const messages = {
 }
 
 export default createI18n({
+  legacy: false,
   locale: 'en',
   fallbackLocale: 'en',
   messages


### PR DESCRIPTION
## Summary
- enable composition API usage in `vue-i18n`
- remove unused `locale` variable to satisfy linter

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6883dbcb56f083318c198ffc1ecef40d