### PR TITLE
Switch to tailwindcss-logical

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "prettier": "^3.5.1",
         "tailwindcss": "^4.0.9",
         "tailwindcss-dir": "^4.0.0",
-        "tailwindcss-rtl": "^0.9.0",
+        "tailwindcss-logical": "^4.0.0",
         "vite": "^6.1.0",
         "vite-plugin-vue-devtools": "^7.7.2"
       }
@@ -3661,17 +3661,6 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
-    "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5241,12 +5230,15 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/tailwindcss-rtl": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss-rtl/-/tailwindcss-rtl-0.9.0.tgz",
-      "integrity": "sha512-y7yC8QXjluDBEFMSX33tV6xMYrf0B3sa+tOB5JSQb6/G6laBU313a+Z+qxu55M1Qyn8tDMttjomsA8IsJD+k+w==",
+    "node_modules/tailwindcss-logical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-logical/-/tailwindcss-logical-4.0.0.tgz",
+      "integrity": "sha512-9oD7tBWGqvEWwCIk5j53bgz+fY6lw0NWrOtMCSHkYECn/UG8pMnA6NwOpv0z8ExDsnOHNXlhOVB0+xgBEkn0Tg==",
       "dev": true,
-      "license": "MIT"
+      "license": "ISC",
+      "peerDependencies": {
+        "tailwindcss": ">=4.0.0"
+      }
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -5706,20 +5698,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "numeral": "^2.0.6",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",
-    "vue-router": "^4.5.0",
-    "vue-i18n": "^9.9.0"
+    "vue-i18n": "^9.9.0",
+    "vue-router": "^4.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.20.0",
@@ -30,9 +30,9 @@
     "eslint-plugin-vue": "^9.32.0",
     "prettier": "^3.5.1",
     "tailwindcss": "^4.0.9",
-    "vite": "^6.1.0",
-    "vite-plugin-vue-devtools": "^7.7.2",
     "tailwindcss-dir": "^4.0.0",
-    "tailwindcss-rtl": "^0.9.0"
+    "tailwindcss-logical": "^4.0.0",
+    "vite": "^6.1.0",
+    "vite-plugin-vue-devtools": "^7.7.2"
   }
 }

--- a/src/components/AsideMenuItem.vue
+++ b/src/components/AsideMenuItem.vue
@@ -68,7 +68,7 @@ const menuClick = (event) => {
       <span
         class="grow text-ellipsis line-clamp-1"
         :class="[
-          { 'pe-12': !hasDropdown },
+          { 'pr-12': !hasDropdown },
           vSlot && vSlot.isExactActive ? asideMenuItemActiveStyle : '',
         ]"
         >{{ t(item.label) }}</span

--- a/src/components/AsideMenuLayer.vue
+++ b/src/components/AsideMenuLayer.vue
@@ -33,11 +33,11 @@ const asideLgCloseClick = (event) => {
 <template>
   <aside
     id="aside"
-    class="lg:py-2 lg:ps-2 w-60 fixed flex z-40 top-0 h-screen transition-position overflow-hidden"
+    class="lg:py-2 lg:pl-2 w-60 fixed flex z-40 top-0 h-screen transition-position overflow-hidden"
   >
     <div class="aside lg:rounded-2xl flex-1 flex flex-col overflow-hidden dark:bg-slate-900">
       <div class="aside-brand flex flex-row h-14 items-center justify-between dark:bg-slate-900">
-        <div class="text-center flex-1 lg:text-left lg:ps-6 xl:text-center xl:ps-0">
+        <div class="text-center flex-1 lg:text-left lg:pl-6 xl:text-center xl:pl-0">
           <b class="font-black">One</b>
         </div>
         <button class="hidden lg:inline-block xl:hidden p-3" @click.prevent="asideLgCloseClick">

--- a/src/components/BaseButtons.vue
+++ b/src/components/BaseButtons.vue
@@ -11,7 +11,7 @@ export default defineComponent({
     },
     classAddon: {
       type: String,
-      default: 'me-3 last:me-0 mb-3',
+      default: 'mr-3 last:mr-0 mb-3',
     },
     mb: {
       type: String,

--- a/src/components/CardBoxClient.vue
+++ b/src/components/CardBoxClient.vue
@@ -68,7 +68,7 @@ const pillText = computed(() => props.text ?? `${props.progress}%`)
   <CardBox class="mb-6 last:mb-0">
     <BaseLevel>
       <BaseLevel type="justify-start">
-        <UserAvatar class="w-12 h-12 me-6" :username="name" />
+        <UserAvatar class="w-12 h-12 mr-6" :username="name" />
         <div class="text-center md:text-left overflow-hidden">
           <h4 class="text-xl text-ellipsis">
             {{ name }}

--- a/src/components/CardBoxComponentHeader.vue
+++ b/src/components/CardBoxComponentHeader.vue
@@ -26,7 +26,7 @@ const buttonClick = (event) => {
 <template>
   <header class="flex items-stretch border-b border-gray-100 dark:border-slate-800">
     <div class="flex items-center py-3 grow font-bold" :class="[icon ? 'px-4' : 'px-6']">
-      <BaseIcon v-if="icon" :path="icon" class="me-3" />
+      <BaseIcon v-if="icon" :path="icon" class="mr-3" />
       {{ title }}
     </div>
     <button

--- a/src/components/CardBoxTransaction.vue
+++ b/src/components/CardBoxTransaction.vue
@@ -62,8 +62,8 @@ const icon = computed(() => {
   <CardBox class="mb-6 last:mb-0">
     <BaseLevel>
       <BaseLevel type="justify-start">
-        <IconRounded :icon="icon.icon" :color="icon.type" class="md:me-6" />
-        <div class="text-center space-y-1 md:text-left md:me-6">
+        <IconRounded :icon="icon.icon" :color="icon.type" class="md:mr-6" />
+        <div class="text-center space-y-1 md:text-left md:mr-6">
           <h4 class="text-xl">${{ amount }}</h4>
           <p class="text-gray-500 dark:text-slate-400">
             <b>{{ date }}</b> via {{ business }}

--- a/src/components/FormCheckRadio.vue
+++ b/src/components/FormCheckRadio.vue
@@ -41,6 +41,6 @@ const inputType = computed(() => (props.type === 'radio' ? 'radio' : 'checkbox')
   <label :class="type">
     <input v-model="computedValue" :type="inputType" :name="name" :value="inputValue" />
     <span class="check" />
-    <span class="ps-2">{{ label }}</span>
+    <span class="pl-2">{{ label }}</span>
   </label>
 </template>

--- a/src/components/FormCheckRadioGroup.vue
+++ b/src/components/FormCheckRadioGroup.vue
@@ -48,7 +48,7 @@ const computedValue = computed({
       :input-value="key"
       :label="value"
       :class="componentClass"
-      class="me-6 mb-3 last:me-0"
+      class="mr-6 mb-3 last:mr-0"
     />
   </div>
 </template>

--- a/src/components/FormControl.vue
+++ b/src/components/FormControl.vue
@@ -69,7 +69,7 @@ const inputElClass = computed(() => {
   ]
 
   if (props.icon) {
-    base.push('ps-10')
+    base.push('pl-10')
   }
 
   return base

--- a/src/components/NavBarItem.vue
+++ b/src/components/NavBarItem.vue
@@ -106,7 +106,7 @@ onBeforeUnmount(() => {
           item.menu,
       }"
     >
-      <UserAvatarCurrentUser v-if="item.isCurrentUser" class="w-6 h-6 me-3 inline-flex" />
+      <UserAvatarCurrentUser v-if="item.isCurrentUser" class="w-6 h-6 mr-3 inline-flex" />
       <BaseIcon v-if="item.icon" :path="item.icon" class="transition-colors" />
       <span
         class="px-2 transition-colors"

--- a/src/components/NotificationBarInCard.vue
+++ b/src/components/NotificationBarInCard.vue
@@ -10,7 +10,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="flex flex-col mb-6 -mt-6 -me-6 -ms-6 animate-fade-in">
+  <div class="flex flex-col mb-6 -mt-6 -mr-6 -ml-6 animate-fade-in">
     <div :class="[colorsBgLight[color]]" class="rounded-t-2xl flex flex-col p-6 transition-colors">
       <slot />
     </div>

--- a/src/components/SectionTitleLineWithButton.vue
+++ b/src/components/SectionTitleLineWithButton.vue
@@ -25,8 +25,8 @@ const { t } = useI18n()
 <template>
   <section :class="{ 'pt-6': !main }" class="mb-6 flex items-center justify-between">
     <div class="flex items-center justify-start">
-      <IconRounded v-if="icon && main" :icon="icon" color="light" class="me-3" bg />
-      <BaseIcon v-else-if="icon" :path="icon" class="me-2" size="20" />
+      <IconRounded v-if="icon && main" :icon="icon" color="light" class="mr-3" bg />
+      <BaseIcon v-else-if="icon" :path="icon" class="mr-2" size="20" />
       <h1 :class="main ? 'text-3xl' : 'text-2xl'" class="leading-tight">
         {{ t(title) }}
       </h1>

--- a/src/css/_table.css
+++ b/src/css/_table.css
@@ -44,6 +44,6 @@
 
   td:before {
     content: attr(data-label);
-    @apply font-semibold pe-3 text-left lg:hidden;
+    @apply font-semibold pr-3 text-left lg:hidden;
   }
 }

--- a/src/layouts/LayoutAuthenticated.vue
+++ b/src/layouts/LayoutAuthenticated.vue
@@ -13,7 +13,7 @@ import NavBarItemPlain from '@/components/NavBarItemPlain.vue'
 import AsideMenu from '@/components/AsideMenu.vue'
 import FooterBar from '@/components/FooterBar.vue'
 
-const layoutAsidePadding = 'xl:ps-60'
+const layoutAsidePadding = 'xl:pl-60'
 
 const darkModeStore = useDarkModeStore()
 
@@ -46,12 +46,12 @@ const menuClick = (event, item) => {
     }"
   >
     <div
-      :class="[layoutAsidePadding, { 'ms-60 lg:ms-0': isAsideMobileExpanded }]"
+      :class="[layoutAsidePadding, { 'ml-60 lg:ml-0': isAsideMobileExpanded }]"
       class="pt-14 min-h-screen w-screen transition-position lg:w-auto bg-gray-50 dark:bg-slate-800 dark:text-slate-100"
     >
       <NavBar
         :menu="menuNavBar"
-        :class="[layoutAsidePadding, { 'ms-60 lg:ms-0': isAsideMobileExpanded }]"
+        :class="[layoutAsidePadding, { 'ml-60 lg:ml-0': isAsideMobileExpanded }]"
         @menu-click="menuClick"
       >
         <NavBarItemPlain

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,7 @@
 /* global require, module */
 
 const plugin = require("tailwindcss/plugin");
-const rtl = require('tailwindcss-rtl');
+const logical = require("tailwindcss-logical");
 
 module.exports = {
   content: ["./index.html", "./src/**/*.{vue,js,ts,jsx,tsx,css}"],
@@ -44,9 +44,9 @@ module.exports = {
     },
   },
   plugins: [
+    logical,
     require("@tailwindcss/forms"),
     require("tailwindcss-dir")(),
-    rtl(),
     plugin(function ({ matchUtilities, theme }) {
       matchUtilities(
         {


### PR DESCRIPTION
## Summary
- swap deprecated `tailwindcss-rtl` for `tailwindcss-logical`
- register the new plugin and remove old `rtl()` call
- replace directional utilities with standard classes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883e7fc851083319fb1ac2382c0b1c5