### PR TITLE
Fix: use logical start/end utils

### DIFF
--- a/src/components/AsideMenu.vue
+++ b/src/components/AsideMenu.vue
@@ -26,7 +26,7 @@ const asideLgCloseClick = (event) => {
   <AsideMenuLayer
     :menu="menu"
     :class="[
-      isAsideMobileExpanded ? 'left-0' : '-left-60 lg:left-0',
+      isAsideMobileExpanded ? 'start-0' : '-start-60 lg:start-0',
       { 'lg:hidden xl:flex': !isAsideLgActive },
     ]"
     @menu-click="menuClick"

--- a/src/components/AsideMenuLayer.vue
+++ b/src/components/AsideMenuLayer.vue
@@ -37,7 +37,7 @@ const asideLgCloseClick = (event) => {
   >
     <div class="aside lg:rounded-2xl flex-1 flex flex-col overflow-hidden dark:bg-slate-900">
       <div class="aside-brand flex flex-row h-14 items-center justify-between dark:bg-slate-900">
-        <div class="text-center flex-1 lg:text-left lg:pl-6 xl:text-center xl:pl-0">
+        <div class="text-center flex-1 lg:text-start lg:pl-6 xl:text-center xl:pl-0">
           <b class="font-black">One</b>
         </div>
         <button class="hidden lg:inline-block xl:hidden p-3" @click.prevent="asideLgCloseClick">

--- a/src/components/BaseButtons.vue
+++ b/src/components/BaseButtons.vue
@@ -11,7 +11,7 @@ export default defineComponent({
     },
     classAddon: {
       type: String,
-      default: 'mr-3 last:mr-0 mb-3',
+      default: 'me-3 last:me-0 mb-3',
     },
     mb: {
       type: String,

--- a/src/components/CardBoxClient.vue
+++ b/src/components/CardBoxClient.vue
@@ -68,8 +68,8 @@ const pillText = computed(() => props.text ?? `${props.progress}%`)
   <CardBox class="mb-6 last:mb-0">
     <BaseLevel>
       <BaseLevel type="justify-start">
-        <UserAvatar class="w-12 h-12 mr-6" :username="name" />
-        <div class="text-center md:text-left overflow-hidden">
+        <UserAvatar class="w-12 h-12 me-6" :username="name" />
+        <div class="text-center md:text-start overflow-hidden">
           <h4 class="text-xl text-ellipsis">
             {{ name }}
           </h4>

--- a/src/components/CardBoxComponentHeader.vue
+++ b/src/components/CardBoxComponentHeader.vue
@@ -26,7 +26,7 @@ const buttonClick = (event) => {
 <template>
   <header class="flex items-stretch border-b border-gray-100 dark:border-slate-800">
     <div class="flex items-center py-3 grow font-bold" :class="[icon ? 'px-4' : 'px-6']">
-      <BaseIcon v-if="icon" :path="icon" class="mr-3" />
+      <BaseIcon v-if="icon" :path="icon" class="me-3" />
       {{ title }}
     </div>
     <button

--- a/src/components/CardBoxTransaction.vue
+++ b/src/components/CardBoxTransaction.vue
@@ -62,15 +62,15 @@ const icon = computed(() => {
   <CardBox class="mb-6 last:mb-0">
     <BaseLevel>
       <BaseLevel type="justify-start">
-        <IconRounded :icon="icon.icon" :color="icon.type" class="md:mr-6" />
-        <div class="text-center space-y-1 md:text-left md:mr-6">
+        <IconRounded :icon="icon.icon" :color="icon.type" class="md:me-6" />
+        <div class="text-center space-y-1 md:text-start md:me-6">
           <h4 class="text-xl">${{ amount }}</h4>
           <p class="text-gray-500 dark:text-slate-400">
             <b>{{ date }}</b> via {{ business }}
           </p>
         </div>
       </BaseLevel>
-      <div class="text-center md:text-right space-y-2">
+      <div class="text-center md:text-end space-y-2">
         <p class="text-sm text-gray-500">
           {{ name }}
         </p>

--- a/src/components/FooterBar.vue
+++ b/src/components/FooterBar.vue
@@ -9,7 +9,7 @@ const year = new Date().getFullYear()
 <template>
   <footer class="py-2 px-6" :class="containerMaxW">
     <BaseLevel>
-      <div class="text-center md:text-left">
+      <div class="text-center md:text-start">
         <b>&copy;{{ year }}, <a href="https://justboil.me/" target="_blank">JustBoil.me</a>.</b>
         <slot />
       </div>

--- a/src/components/FormCheckRadioGroup.vue
+++ b/src/components/FormCheckRadioGroup.vue
@@ -48,7 +48,7 @@ const computedValue = computed({
       :input-value="key"
       :label="value"
       :class="componentClass"
-      class="mr-6 mb-3 last:mr-0"
+      class="me-6 mb-3 last:me-0"
     />
   </div>
 </template>

--- a/src/components/FormControlIcon.vue
+++ b/src/components/FormControlIcon.vue
@@ -18,6 +18,6 @@ defineProps({
     :path="icon"
     w="w-10"
     :h="h"
-    class="absolute top-0 left-0 z-10 pointer-events-none text-gray-500 dark:text-slate-400"
+    class="absolute top-0 start-0 z-10 pointer-events-none text-gray-500 dark:text-slate-400"
   />
 </template>

--- a/src/components/FormFilePicker.vue
+++ b/src/components/FormFilePicker.vue
@@ -97,7 +97,7 @@ const upload = (event) => {
       <input
         ref="root"
         type="file"
-        class="absolute top-0 left-0 w-full h-full opacity-0 outline-hidden cursor-pointer -z-1"
+        class="absolute top-0 start-0 w-full h-full opacity-0 outline-hidden cursor-pointer -z-1"
         :accept="accept"
         @input="upload"
       />

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -36,7 +36,7 @@ const isMenuNavBarActive = ref(false)
         </NavBarItemPlain>
       </div>
       <div
-        class="max-h-screen-menu overflow-y-auto lg:overflow-visible absolute w-screen top-14 left-0 bg-gray-50 shadow-lg lg:w-auto lg:flex lg:static lg:shadow-none dark:bg-slate-800"
+        class="max-h-screen-menu overflow-y-auto lg:overflow-visible absolute w-screen top-14 start-0 bg-gray-50 shadow-lg lg:w-auto lg:flex lg:static lg:shadow-none dark:bg-slate-800"
         :class="[isMenuNavBarActive ? 'block' : 'hidden']"
       >
         <NavBarMenuList :menu="menu" @menu-click="menuClick" />

--- a/src/components/NavBarItem.vue
+++ b/src/components/NavBarItem.vue
@@ -106,7 +106,7 @@ onBeforeUnmount(() => {
           item.menu,
       }"
     >
-      <UserAvatarCurrentUser v-if="item.isCurrentUser" class="w-6 h-6 mr-3 inline-flex" />
+      <UserAvatarCurrentUser v-if="item.isCurrentUser" class="w-6 h-6 me-3 inline-flex" />
       <BaseIcon v-if="item.icon" :path="item.icon" class="transition-colors" />
       <span
         class="px-2 transition-colors"
@@ -121,7 +121,7 @@ onBeforeUnmount(() => {
     </div>
     <div
       v-if="item.menu"
-      class="text-sm border-b border-gray-100 lg:border lg:bg-white lg:absolute lg:top-full lg:left-0 lg:min-w-full lg:z-20 lg:rounded-lg lg:shadow-lg lg:dark:bg-slate-800 dark:border-slate-700"
+      class="text-sm border-b border-gray-100 lg:border lg:bg-white lg:absolute lg:top-full lg:start-0 lg:min-w-full lg:z-20 lg:rounded-lg lg:shadow-lg lg:dark:bg-slate-800 dark:border-slate-700"
       :class="{ 'lg:hidden': !isDropdownActive }"
     >
       <NavBarMenuList :menu="item.menu" @menu-click="menuClickDropdown" />

--- a/src/components/NotificationBar.vue
+++ b/src/components/NotificationBar.vue
@@ -47,9 +47,9 @@ const hasRightSlot = computed(() => slots.right)
           w="w-10 md:w-5"
           h="h-10 md:h-5"
           size="24"
-          class="md:mr-2"
+          class="md:me-2"
         />
-        <span class="text-center md:text-left md:py-2"><slot /></span>
+        <span class="text-center md:text-start md:py-2"><slot /></span>
       </div>
       <slot v-if="hasRightSlot" name="right" />
       <BaseButton v-else :icon="mdiClose" small rounded-full color="white" @click="dismiss" />

--- a/src/components/NotificationBarInCard.vue
+++ b/src/components/NotificationBarInCard.vue
@@ -10,7 +10,7 @@ defineProps({
 </script>
 
 <template>
-  <div class="flex flex-col mb-6 -mt-6 -mr-6 -ml-6 animate-fade-in">
+  <div class="flex flex-col mb-6 -mt-6 -me-6 -ms-6 animate-fade-in">
     <div :class="[colorsBgLight[color]]" class="rounded-t-2xl flex flex-col p-6 transition-colors">
       <slot />
     </div>

--- a/src/components/PillTagPlain.vue
+++ b/src/components/PillTagPlain.vue
@@ -24,7 +24,7 @@ defineProps({
       :path="icon"
       h="h-4"
       w="w-4"
-      :class="small ? 'mr-1' : 'mr-2'"
+      :class="small ? 'me-1' : 'me-2'"
       :size="small ? 14 : null"
     />
     <span>{{ label }}</span>

--- a/src/components/SectionTitleLineWithButton.vue
+++ b/src/components/SectionTitleLineWithButton.vue
@@ -25,8 +25,8 @@ const { t } = useI18n()
 <template>
   <section :class="{ 'pt-6': !main }" class="mb-6 flex items-center justify-between">
     <div class="flex items-center justify-start">
-      <IconRounded v-if="icon && main" :icon="icon" color="light" class="mr-3" bg />
-      <BaseIcon v-else-if="icon" :path="icon" class="mr-2" size="20" />
+      <IconRounded v-if="icon && main" :icon="icon" color="light" class="me-3" bg />
+      <BaseIcon v-else-if="icon" :path="icon" class="me-2" size="20" />
       <h1 :class="main ? 'text-3xl' : 'text-2xl'" class="leading-tight">
         {{ t(title) }}
       </h1>

--- a/src/components/UserCard.vue
+++ b/src/components/UserCard.vue
@@ -19,7 +19,7 @@ const userSwitchVal = ref(false)
   <CardBox>
     <BaseLevel type="justify-around lg:justify-center">
       <UserAvatarCurrentUser class="lg:mx-12" />
-      <div class="space-y-3 text-center md:text-left lg:mx-12">
+      <div class="space-y-3 text-center md:text-start lg:mx-12">
         <div class="flex justify-center md:block">
           <FormCheckRadio
             v-model="userSwitchVal"

--- a/src/css/_checkbox-radio-switch.css
+++ b/src/css/_checkbox-radio-switch.css
@@ -2,7 +2,7 @@
   @apply inline-flex items-center cursor-pointer relative;
 
   & input[type='checkbox'] {
-    @apply absolute left-0 opacity-0 -z-1;
+    @apply absolute start-0 opacity-0 -z-1;
   }
 
   & input[type='checkbox'] + .check {
@@ -38,7 +38,7 @@
   @apply inline-flex items-center cursor-pointer relative;
 
   & input[type='radio'] {
-    @apply absolute left-0 opacity-0 -z-1;
+    @apply absolute start-0 opacity-0 -z-1;
   }
 
   & input[type='radio'] + .check {
@@ -74,7 +74,7 @@
   @apply inline-flex items-center cursor-pointer relative;
 
   & input[type='checkbox'] {
-    @apply absolute left-0 opacity-0 -z-1;
+    @apply absolute start-0 opacity-0 -z-1;
   }
 
   & input[type='checkbox'] + .check {

--- a/src/css/_table.css
+++ b/src/css/_table.css
@@ -17,16 +17,16 @@
   }
 
   td:not(:first-child) {
-    @apply lg:border-l lg:border-t-0 lg:border-r-0 lg:border-b-0 lg:border-gray-100 lg:dark:border-slate-700;
+    @apply lg:border-s lg:border-t-0 lg:border-e-0 lg:border-b-0 lg:border-gray-100 lg:dark:border-slate-700;
   }
 
   th {
-    @apply lg:text-left lg:p-3;
+    @apply lg:text-start lg:p-3;
   }
 
   td {
-    @apply flex justify-between text-right py-3 px-4 align-top border-b border-gray-100
-      lg:table-cell lg:text-left lg:p-3 lg:align-middle lg:border-b-0 dark:border-slate-800;
+    @apply flex justify-between text-end py-3 px-4 align-top border-b border-gray-100
+      lg:table-cell lg:text-start lg:p-3 lg:align-middle lg:border-b-0 dark:border-slate-800;
   }
 
   td:last-child {
@@ -44,6 +44,6 @@
 
   td:before {
     content: attr(data-label);
-    @apply font-semibold pr-3 text-left lg:hidden;
+    @apply font-semibold pr-3 text-start lg:hidden;
   }
 }

--- a/src/layouts/LayoutAuthenticated.vue
+++ b/src/layouts/LayoutAuthenticated.vue
@@ -46,12 +46,12 @@ const menuClick = (event, item) => {
     }"
   >
     <div
-      :class="[layoutAsidePadding, { 'ml-60 lg:ml-0': isAsideMobileExpanded }]"
+      :class="[layoutAsidePadding, { 'ms-60 lg:ms-0': isAsideMobileExpanded }]"
       class="pt-14 min-h-screen w-screen transition-position lg:w-auto bg-gray-50 dark:bg-slate-800 dark:text-slate-100"
     >
       <NavBar
         :menu="menuNavBar"
-        :class="[layoutAsidePadding, { 'ml-60 lg:ml-0': isAsideMobileExpanded }]"
+        :class="[layoutAsidePadding, { 'ms-60 lg:ms-0': isAsideMobileExpanded }]"
         @menu-click="menuClick"
       >
         <NavBarItemPlain

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,7 +24,8 @@ module.exports = {
         modal: "calc(100vh - 160px)",
       },
       transitionProperty: {
-        position: "right, left, top, bottom, margin, padding",
+        position:
+          "inset-inline-start, inset-inline-end, top, bottom, margin-inline-start, margin-inline-end, padding-inline-start, padding-inline-end",
         textColor: "color",
       },
       keyframes: {


### PR DESCRIPTION
## Summary
- use margin-start/end in Vue components
- update text alignment classes in Vue and CSS
- switch positional classes to logical `start`
- adjust table styles for border and text alignment
- allow transitions for logical inset and margins
- run ESLint auto-fix

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6884f43c50e083318fbc27498e5bc098