### PR TITLE
Fix padding utilities for RTL support

### DIFF
--- a/src/components/AsideMenuItem.vue
+++ b/src/components/AsideMenuItem.vue
@@ -68,7 +68,7 @@ const menuClick = (event) => {
       <span
         class="grow text-ellipsis line-clamp-1"
         :class="[
-          { 'pr-12': !hasDropdown },
+          { 'pe-12': !hasDropdown },
           vSlot && vSlot.isExactActive ? asideMenuItemActiveStyle : '',
         ]"
         >{{ t(item.label) }}</span

--- a/src/components/AsideMenuLayer.vue
+++ b/src/components/AsideMenuLayer.vue
@@ -33,11 +33,11 @@ const asideLgCloseClick = (event) => {
 <template>
   <aside
     id="aside"
-    class="lg:py-2 lg:pl-2 w-60 fixed flex z-40 top-0 h-screen transition-position overflow-hidden"
+    class="lg:py-2 lg:ps-2 w-60 fixed flex z-40 top-0 h-screen transition-position overflow-hidden"
   >
     <div class="aside lg:rounded-2xl flex-1 flex flex-col overflow-hidden dark:bg-slate-900">
       <div class="aside-brand flex flex-row h-14 items-center justify-between dark:bg-slate-900">
-        <div class="text-center flex-1 lg:text-start lg:pl-6 xl:text-center xl:pl-0">
+        <div class="text-center flex-1 lg:text-start lg:ps-6 xl:text-center xl:ps-0">
           <b class="font-black">One</b>
         </div>
         <button class="hidden lg:inline-block xl:hidden p-3" @click.prevent="asideLgCloseClick">

--- a/src/components/FormCheckRadio.vue
+++ b/src/components/FormCheckRadio.vue
@@ -41,6 +41,6 @@ const inputType = computed(() => (props.type === 'radio' ? 'radio' : 'checkbox')
   <label :class="type">
     <input v-model="computedValue" :type="inputType" :name="name" :value="inputValue" />
     <span class="check" />
-    <span class="pl-2">{{ label }}</span>
+    <span class="ps-2">{{ label }}</span>
   </label>
 </template>

--- a/src/components/FormControl.vue
+++ b/src/components/FormControl.vue
@@ -69,7 +69,7 @@ const inputElClass = computed(() => {
   ]
 
   if (props.icon) {
-    base.push('pl-10')
+    base.push('ps-10')
   }
 
   return base

--- a/src/css/_table.css
+++ b/src/css/_table.css
@@ -44,6 +44,6 @@
 
   td:before {
     content: attr(data-label);
-    @apply font-semibold pr-3 text-start lg:hidden;
+    @apply font-semibold pe-3 text-start lg:hidden;
   }
 }

--- a/src/layouts/LayoutAuthenticated.vue
+++ b/src/layouts/LayoutAuthenticated.vue
@@ -13,7 +13,7 @@ import NavBarItemPlain from '@/components/NavBarItemPlain.vue'
 import AsideMenu from '@/components/AsideMenu.vue'
 import FooterBar from '@/components/FooterBar.vue'
 
-const layoutAsidePadding = 'xl:pl-60'
+const layoutAsidePadding = 'xl:ps-60'
 
 const darkModeStore = useDarkModeStore()
 


### PR DESCRIPTION
## Summary
- switch to logical padding utilities in LayoutAuthenticated
- replace `pl-*` and `pr-*` with `ps-*` and `pe-*`
- apply new padding utilities to CSS table layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885105538648331865abe76317c272c