### PR TITLE
Add pagination to driver cards table

### DIFF
--- a/src/components/TableDriverCards.vue
+++ b/src/components/TableDriverCards.vue
@@ -1,7 +1,9 @@
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import BaseButton from '@/components/BaseButton.vue'
+import BaseButtons from '@/components/BaseButtons.vue'
+import BaseLevel from '@/components/BaseLevel.vue'
 import { useDriverCardsStore } from '@/stores/driverCards'
 
 const router = useRouter()
@@ -14,6 +16,29 @@ onMounted(() => {
 function editCard(card) {
   router.push({ name: 'driver-card-workflow', query: { id: card.ID } })
 }
+
+const perPage = ref(10)
+const currentPage = ref(0)
+
+const items = computed(() => store.cards)
+
+const itemsPaginated = computed(() =>
+  items.value.slice(perPage.value * currentPage.value, perPage.value * (currentPage.value + 1)),
+)
+
+const numPages = computed(() => Math.ceil(items.value.length / perPage.value))
+
+const currentPageHuman = computed(() => currentPage.value + 1)
+
+const pagesList = computed(() => {
+  const pagesList = []
+
+  for (let i = 0; i < numPages.value; i++) {
+    pagesList.push(i)
+  }
+
+  return pagesList
+})
 </script>
 
 <template>
@@ -30,7 +55,7 @@ function editCard(card) {
       </tr>
     </thead>
     <tbody>
-      <tr v-for="card in store.cards" :key="card.ID">
+      <tr v-for="card in itemsPaginated" :key="card.ID">
         <td>{{ card.ID }}</td>
         <td>
           <a
@@ -50,4 +75,20 @@ function editCard(card) {
       </tr>
     </tbody>
   </table>
+  <div class="p-3 lg:px-6 border-t border-gray-100 dark:border-slate-800">
+    <BaseLevel>
+      <BaseButtons>
+        <BaseButton
+          v-for="page in pagesList"
+          :key="page"
+          :active="page === currentPage"
+          :label="page + 1"
+          :color="page === currentPage ? 'lightDark' : 'whiteDark'"
+          small
+          @click="currentPage = page"
+        />
+      </BaseButtons>
+      <small>Page {{ currentPageHuman }} of {{ numPages }}</small>
+    </BaseLevel>
+  </div>
 </template>


### PR DESCRIPTION
## Summary
- paginate Driver Cards table with numbered buttons and page info
- match layout & behavior of other tables

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68851a402b288331bd1a69e500ce2f35