### PR TITLE
Add vehicles, drivers and facilities stores

### DIFF
--- a/src/stores/drivers.js
+++ b/src/stores/drivers.js
@@ -1,0 +1,58 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  getDrivers,
+  addDriver,
+  updateDriver as apiUpdate,
+  deleteDriver as apiDelete,
+} from '@/api/drivers'
+
+export const useDriversStore = defineStore('drivers', () => {
+  const drivers = ref([])
+
+  async function fetchDrivers() {
+    try {
+      const { data } = await getDrivers()
+      drivers.value = data
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function createDriver(payload) {
+    try {
+      const { data } = await addDriver(payload)
+      drivers.value.push(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function updateDriver(id, payload) {
+    try {
+      const { data } = await apiUpdate(id, payload)
+      const index = drivers.value.findIndex((d) => d.DriverID === id || d.ID === id)
+      if (index !== -1) {
+        drivers.value[index] = data
+      } else {
+        drivers.value.push(data)
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function deleteDriver(id) {
+    try {
+      await apiDelete(id)
+      const index = drivers.value.findIndex((d) => d.DriverID === id || d.ID === id)
+      if (index !== -1) {
+        drivers.value.splice(index, 1)
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return { drivers, fetchDrivers, createDriver, updateDriver, deleteDriver }
+})

--- a/src/stores/facilities.js
+++ b/src/stores/facilities.js
@@ -1,0 +1,36 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  getFacilities,
+  addFacility,
+  searchFacilities,
+} from '@/api/facilities'
+
+export const useFacilitiesStore = defineStore('facilities', () => {
+  const facilities = ref([])
+
+  async function fetchFacilities(options = null) {
+    try {
+      if (options && (options.search || options.limit || options.offset)) {
+        const { data } = await searchFacilities(options)
+        facilities.value = data
+      } else {
+        const { data } = await getFacilities()
+        facilities.value = data
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function createFacility(payload) {
+    try {
+      const { data } = await addFacility(payload)
+      facilities.value.push(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return { facilities, fetchFacilities, createFacility }
+})

--- a/src/stores/vehicles.js
+++ b/src/stores/vehicles.js
@@ -1,0 +1,58 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import {
+  getVehicles,
+  addVehicle,
+  updateVehicle as apiUpdate,
+  deleteVehicle as apiDelete,
+} from '@/api/vehicles'
+
+export const useVehiclesStore = defineStore('vehicles', () => {
+  const vehicles = ref([])
+
+  async function fetchVehicles() {
+    try {
+      const { data } = await getVehicles()
+      vehicles.value = data
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function createVehicle(payload) {
+    try {
+      const { data } = await addVehicle(payload)
+      vehicles.value.push(data)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function updateVehicle(id, payload) {
+    try {
+      const { data } = await apiUpdate(id, payload)
+      const index = vehicles.value.findIndex((v) => v.VehicleID === id || v.ID === id)
+      if (index !== -1) {
+        vehicles.value[index] = data
+      } else {
+        vehicles.value.push(data)
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  async function deleteVehicle(id) {
+    try {
+      await apiDelete(id)
+      const index = vehicles.value.findIndex((v) => v.VehicleID === id || v.ID === id)
+      if (index !== -1) {
+        vehicles.value.splice(index, 1)
+      }
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  return { vehicles, fetchVehicles, createVehicle, updateVehicle, deleteVehicle }
+})


### PR DESCRIPTION
## Summary
- add `vehicles`, `drivers`, and `facilities` Pinia stores
- expose CRUD actions for vehicles and drivers
- allow facilities to be fetched with optional pagination

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885236358d88331bd40565c0081b200