### PR TITLE
Add pagination to data tables

### DIFF
--- a/src/components/TableDrivers.vue
+++ b/src/components/TableDrivers.vue
@@ -1,6 +1,8 @@
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed, ref } from 'vue'
 import BaseButton from '@/components/BaseButton.vue'
+import BaseLevel from '@/components/BaseLevel.vue'
+import BasePagination from '@/components/BasePagination.vue'
 import { useDriversStore } from '@/stores/drivers'
 
 const emit = defineEmits(['edit'])
@@ -10,6 +12,22 @@ const store = useDriversStore()
 onMounted(() => {
   store.fetchDrivers()
 })
+
+const perPage = ref(10)
+const currentPage = ref(0)
+
+const items = computed(() => store.drivers)
+
+const itemsPaginated = computed(() =>
+  items.value.slice(
+    perPage.value * currentPage.value,
+    perPage.value * (currentPage.value + 1),
+  ),
+)
+
+const numPages = computed(() => Math.ceil(items.value.length / perPage.value))
+
+const currentPageHuman = computed(() => currentPage.value + 1)
 
 function editDriver(driver) {
   emit('edit', driver)
@@ -29,7 +47,7 @@ function editDriver(driver) {
       </tr>
     </thead>
     <tbody>
-      <tr v-for="driver in store.drivers" :key="driver.DriverID">
+      <tr v-for="driver in itemsPaginated" :key="driver.DriverID">
         <td>{{ driver.DriverID }}</td>
         <td>{{ driver.FirstName }}</td>
         <td>{{ driver.LastName }}</td>
@@ -41,4 +59,10 @@ function editDriver(driver) {
       </tr>
     </tbody>
   </table>
+  <div class="p-3 lg:px-6 border-t border-gray-100 dark:border-slate-800">
+    <BaseLevel>
+      <BasePagination v-model="currentPage" :total="numPages" />
+      <small>Page {{ currentPageHuman }} of {{ numPages }}</small>
+    </BaseLevel>
+  </div>
 </template>

--- a/src/components/TableFacilities.vue
+++ b/src/components/TableFacilities.vue
@@ -1,6 +1,8 @@
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed, ref } from 'vue'
 import BaseButton from '@/components/BaseButton.vue'
+import BaseLevel from '@/components/BaseLevel.vue'
+import BasePagination from '@/components/BasePagination.vue'
 import { useFacilitiesStore } from '@/stores/facilities'
 
 const emit = defineEmits(['edit'])
@@ -10,6 +12,22 @@ const store = useFacilitiesStore()
 onMounted(() => {
   store.fetchFacilities()
 })
+
+const perPage = ref(10)
+const currentPage = ref(0)
+
+const items = computed(() => store.facilities)
+
+const itemsPaginated = computed(() =>
+  items.value.slice(
+    perPage.value * currentPage.value,
+    perPage.value * (currentPage.value + 1),
+  ),
+)
+
+const numPages = computed(() => Math.ceil(items.value.length / perPage.value))
+
+const currentPageHuman = computed(() => currentPage.value + 1)
 
 function editFacility(facility) {
   emit('edit', facility)
@@ -27,7 +45,7 @@ function editFacility(facility) {
       </tr>
     </thead>
     <tbody>
-      <tr v-for="facility in store.facilities" :key="facility.FacilityID">
+      <tr v-for="facility in itemsPaginated" :key="facility.FacilityID">
         <td>{{ facility.FacilityID }}</td>
         <td>{{ facility.IdentityNumber }}</td>
         <td>{{ facility.Name }}</td>
@@ -37,4 +55,10 @@ function editFacility(facility) {
       </tr>
     </tbody>
   </table>
+  <div class="p-3 lg:px-6 border-t border-gray-100 dark:border-slate-800">
+    <BaseLevel>
+      <BasePagination v-model="currentPage" :total="numPages" />
+      <small>Page {{ currentPageHuman }} of {{ numPages }}</small>
+    </BaseLevel>
+  </div>
 </template>

--- a/src/components/TableVehicles.vue
+++ b/src/components/TableVehicles.vue
@@ -1,6 +1,8 @@
 <script setup>
-import { onMounted } from 'vue'
+import { onMounted, computed, ref } from 'vue'
 import BaseButton from '@/components/BaseButton.vue'
+import BaseLevel from '@/components/BaseLevel.vue'
+import BasePagination from '@/components/BasePagination.vue'
 import { useVehiclesStore } from '@/stores/vehicles'
 
 const emit = defineEmits(['edit'])
@@ -10,6 +12,22 @@ const store = useVehiclesStore()
 onMounted(() => {
   store.fetchVehicles()
 })
+
+const perPage = ref(10)
+const currentPage = ref(0)
+
+const items = computed(() => store.vehicles)
+
+const itemsPaginated = computed(() =>
+  items.value.slice(
+    perPage.value * currentPage.value,
+    perPage.value * (currentPage.value + 1),
+  ),
+)
+
+const numPages = computed(() => Math.ceil(items.value.length / perPage.value))
+
+const currentPageHuman = computed(() => currentPage.value + 1)
 
 function editVehicle(vehicle) {
   emit('edit', vehicle)
@@ -28,7 +46,7 @@ function editVehicle(vehicle) {
       </tr>
     </thead>
     <tbody>
-      <tr v-for="vehicle in store.vehicles" :key="vehicle.ID">
+      <tr v-for="vehicle in itemsPaginated" :key="vehicle.ID">
         <td>{{ vehicle.ID }}</td>
         <td>{{ vehicle.PlateNumber }}</td>
         <td>{{ vehicle.SerialNumber }}</td>
@@ -39,4 +57,10 @@ function editVehicle(vehicle) {
       </tr>
     </tbody>
   </table>
+  <div class="p-3 lg:px-6 border-t border-gray-100 dark:border-slate-800">
+    <BaseLevel>
+      <BasePagination v-model="currentPage" :total="numPages" />
+      <small>Page {{ currentPageHuman }} of {{ numPages }}</small>
+    </BaseLevel>
+  </div>
 </template>


### PR DESCRIPTION
## Summary
- add pagination controls to Drivers, Vehicles and Facilities tables
- paginate store data by page and show controls

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68852e3a0ed88331bfa9018f9d16332b