### PR TITLE
Add Hijri date picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "4.0.0",
       "dependencies": {
         "@mdi/js": "^7.4.47",
+        "@vuepic/vue-datepicker": "^11.0.2",
         "axios": "^1.8.1",
         "chart.js": "^4.4.0",
+        "moment-hijri": "^3.0.0",
         "numeral": "^2.0.6",
         "pinia": "^3.0.1",
         "vue": "^3.5.13",
@@ -2123,6 +2125,21 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.13.tgz",
       "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="
     },
+    "node_modules/@vuepic/vue-datepicker": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-11.0.2.tgz",
+      "integrity": "sha512-uHh78mVBXCEjam1uVfTzZ/HkyDwut/H6b2djSN9YTF+l/EA+XONfdCnOVSi1g+qVGSy65DcQAwyBNidAssnudQ==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "vue": ">=3.3.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -2585,6 +2602,16 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.0",
@@ -4086,6 +4113,24 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-hijri": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/moment-hijri/-/moment-hijri-3.0.0.tgz",
+      "integrity": "sha512-UcBcbHDA8ToVcKjY+vBEa/hI3GZYraueavWUSLY2TdrHDHhx+wUpRw96rssAqsbT4xo/TMimwQVBP4KhJ3EN5A==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.30.1"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
   },
   "dependencies": {
     "@mdi/js": "^7.4.47",
+    "@vuepic/vue-datepicker": "^11.0.2",
     "axios": "^1.8.1",
     "chart.js": "^4.4.0",
+    "moment-hijri": "^3.0.0",
     "numeral": "^2.0.6",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",

--- a/src/components/HijriDatePicker.vue
+++ b/src/components/HijriDatePicker.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { ref, watch } from 'vue'
+import VueDatePicker from '@vuepic/vue-datepicker'
+import '@vuepic/vue-datepicker/dist/main.css'
+import moment from 'moment-hijri'
+
+const props = defineProps({
+  modelValue: {
+    type: String,
+    default: '',
+  },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const innerValue = ref(null)
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    innerValue.value = val ? moment(val, 'iYYYY-iMM-iDD').toDate() : null
+  },
+  { immediate: true },
+)
+
+watch(
+  innerValue,
+  (val) => {
+    if (val) {
+      emit('update:modelValue', moment(val).format('iYYYY-iMM-iDD'))
+    } else {
+      emit('update:modelValue', '')
+    }
+  },
+)
+</script>
+
+<template>
+  <VueDatePicker
+    v-model="innerValue"
+    :input-class="'px-3 py-2 h-12 w-full border rounded-sm bg-white dark:bg-slate-800 focus:ring-3 focus:outline-hidden'"
+  />
+</template>

--- a/src/views/DriverCardWorkflow.vue
+++ b/src/views/DriverCardWorkflow.vue
@@ -11,6 +11,8 @@ import SectionTitleLineWithButton from '@/components/SectionTitleLineWithButton.
 import CardBox from '@/components/CardBox.vue'
 import FormField from '@/components/FormField.vue'
 import FormControl from '@/components/FormControl.vue'
+import HijriDatePicker from '@/components/HijriDatePicker.vue'
+import moment from 'moment-hijri'
 import BaseButtons from '@/components/BaseButtons.vue'
 import BaseButton from '@/components/BaseButton.vue'
 import CardBoxModal from '@/components/CardBoxModal.vue'
@@ -65,9 +67,8 @@ watch(
   () => cardForm.value.IssueDate,
   (val) => {
     if (val) {
-      const d = new Date(val)
-      d.setFullYear(d.getFullYear() + 1)
-      cardForm.value.ExpirationDate = d.toISOString().slice(0, 10)
+      const d = moment(val, 'iYYYY-iMM-iDD').add(1, 'iYear')
+      cardForm.value.ExpirationDate = d.format('iYYYY-iMM-iDD')
     } else {
       cardForm.value.ExpirationDate = ''
     }
@@ -211,10 +212,10 @@ async function saveCard() {
           <FormControl v-model="cardForm.CardType" />
         </FormField>
         <FormField label="Issue Date">
-          <FormControl v-model="cardForm.IssueDate" type="date" />
+          <HijriDatePicker v-model="cardForm.IssueDate" />
         </FormField>
         <FormField label="Expiration Date">
-          <FormControl v-model="cardForm.ExpirationDate" type="date" />
+          <HijriDatePicker v-model="cardForm.ExpirationDate" />
         </FormField>
         <template #footer>
           <BaseButtons>
@@ -256,10 +257,10 @@ async function saveCard() {
         <FormControl v-model="newFacility.LicenseCityEn" />
       </FormField>
       <FormField label="License Issue Date">
-        <FormControl v-model="newFacility.LicenseIssueDate" type="date" />
+        <HijriDatePicker v-model="newFacility.LicenseIssueDate" />
       </FormField>
       <FormField label="License Expiration Date">
-        <FormControl v-model="newFacility.LicenseExpirationDate" type="date" />
+        <HijriDatePicker v-model="newFacility.LicenseExpirationDate" />
       </FormField>
     </CardBoxModal>
 


### PR DESCRIPTION
## Summary
- install `@vuepic/vue-datepicker` and `moment-hijri`
- create `HijriDatePicker` component for Hijri formatted dates
- use `HijriDatePicker` in `DriverCardWorkflow` forms
- update expiration date logic to add one Hijri year

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68852f77959c83318edbc9f3beb8f505