### PR TITLE
Update card date handling

### DIFF
--- a/src/stores/driverCardWorkflow.js
+++ b/src/stores/driverCardWorkflow.js
@@ -41,11 +41,14 @@ export const useDriverCardWorkflowStore = defineStore('driverCardWorkflow', () =
   }
 
   async function saveCard(payload) {
+    const dataPayload = { ...payload }
+    delete dataPayload.addingDate
+    delete dataPayload.LastUpdate
     if (card.value) {
-      const { data } = await updateDriverCard(card.value.ID, payload)
+      const { data } = await updateDriverCard(card.value.ID, dataPayload)
       card.value = data
     } else {
-      const { data } = await addDriverCard(payload)
+      const { data } = await addDriverCard(dataPayload)
       card.value = data
     }
     return card.value

--- a/src/stores/driverCards.js
+++ b/src/stores/driverCards.js
@@ -38,7 +38,10 @@ export const useDriverCardsStore = defineStore('driverCards', () => {
 
   async function createDriverCard(payload) {
     try {
-      const { data } = await addDriverCard(payload)
+      const dataPayload = { ...payload }
+      delete dataPayload.addingDate
+      delete dataPayload.LastUpdate
+      const { data } = await addDriverCard(dataPayload)
       const [card] = await mergeCardData([data])
       cards.value.push(card)
     } catch (err) {
@@ -48,7 +51,10 @@ export const useDriverCardsStore = defineStore('driverCards', () => {
 
   async function updateDriverCard(id, payload) {
     try {
-      const { data } = await apiUpdate(id, payload)
+      const dataPayload = { ...payload }
+      delete dataPayload.addingDate
+      delete dataPayload.LastUpdate
+      const { data } = await apiUpdate(id, dataPayload)
       const [card] = await mergeCardData([data])
       const index = cards.value.findIndex((c) => c.ID === id)
       if (index !== -1) {


### PR DESCRIPTION
## Summary
- auto-populate `addingDate` and `LastUpdate` on card creation
- preserve `addingDate` while always updating `LastUpdate` on update
- prevent frontend stores from sending date fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688530c8a4248331b0dfd64366ea5cf2