### PR TITLE
Fix driver card creation return value

### DIFF
--- a/backend/routes/driverCards.js
+++ b/backend/routes/driverCards.js
@@ -42,11 +42,12 @@ router.post('/', async (req, res) => {
     const today = new Date().toISOString().split('T')[0]
     if (!addingDate) addingDate = today
     if (!LastUpdate) LastUpdate = today
-    await pool.query(
+    const [result] = await pool.query(
       'INSERT INTO OPC_DriverCard (token, CardNumber, CardType, FacilityID, DriverID, IssueDate, ExpirationDate, Supplier, addingDate, LastUpdate, userID) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
       [token, CardNumber, CardType, FacilityID, DriverID, IssueDate, ExpirationDate, Supplier, addingDate, LastUpdate, userID],
     )
-    res.status(201).json({ CardNumber })
+    const [row] = await pool.query('SELECT * FROM OPC_DriverCard WHERE ID = ?', [result.insertId])
+    res.status(201).json(row[0])
   } catch (err) {
     console.error(err)
     res.status(500).json({ error: 'Database error' })

--- a/src/stores/driverCardWorkflow.js
+++ b/src/stores/driverCardWorkflow.js
@@ -44,13 +44,13 @@ export const useDriverCardWorkflowStore = defineStore('driverCardWorkflow', () =
     const dataPayload = { ...payload }
     delete dataPayload.addingDate
     delete dataPayload.LastUpdate
-    if (card.value) {
-      const { data } = await updateDriverCard(card.value.ID, dataPayload)
-      card.value = data
+    let response
+    if (card.value && card.value.ID) {
+      response = await updateDriverCard(card.value.ID, dataPayload)
     } else {
-      const { data } = await addDriverCard(dataPayload)
-      card.value = data
+      response = await addDriverCard(dataPayload)
     }
+    card.value = response.data
     return card.value
   }
 

--- a/src/views/DriverCardWorkflow.vue
+++ b/src/views/DriverCardWorkflow.vue
@@ -150,7 +150,8 @@ async function generateCard() {
     FacilityID: store.facility?.FacilityID || '',
     DriverID: store.driver?.DriverID || '',
   }
-  await store.saveCard(payload)
+  const saved = await store.saveCard(payload)
+  store.card = saved
   cardForm.value.CardNumber = store.card?.CardNumber || ''
 }
 


### PR DESCRIPTION
## Summary
- return the inserted driver card record from the API
- track the returned ID in driver card workflow store
- ensure `generateCard` keeps the workflow store updated

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885357065288331bfc32414c829c006