### PR TITLE
Add readonly prop to FormControl component

### DIFF
--- a/src/components/FormControl.vue
+++ b/src/components/FormControl.vue
@@ -48,6 +48,7 @@ const props = defineProps({
   borderless: Boolean,
   transparent: Boolean,
   ctrlKFocus: Boolean,
+  readonly: Boolean,
 })
 
 const emit = defineEmits(['update:modelValue', 'setRef'])
@@ -145,6 +146,7 @@ if (props.ctrlKFocus) {
       :maxlength="maxlength"
       :placeholder="placeholder"
       :required="required"
+      :readonly="readonly"
     />
     <input
       v-else
@@ -156,6 +158,7 @@ if (props.ctrlKFocus) {
       :inputmode="inputmode"
       :autocomplete="autocomplete"
       :required="required"
+      :readonly="readonly"
       :placeholder="placeholder"
       :type="computedType"
       :class="inputElClass"


### PR DESCRIPTION
## Summary
- expose a new `readonly` prop in `FormControl.vue`
- bind the prop to `<input>` and `<textarea>`
- keep existing readonly usage in `DriverCardWorkflow.vue`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6885362f423c8331b36e6c5d8cfc9c9b