### PR TITLE
Add Hijri picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "numeral": "^2.0.6",
         "pinia": "^3.0.1",
         "vue": "^3.5.13",
+        "vue-hijri-picker": "^1.0.5",
         "vue-i18n": "^9.9.0",
         "vue-router": "^4.5.0"
       },
@@ -5641,6 +5642,37 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/vue-hijri-picker": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/vue-hijri-picker/-/vue-hijri-picker-1.0.5.tgz",
+      "integrity": "sha512-UNlDBuHDTJrN96PsZGKHKdYznnrEZqKsG1Xug4anpQaKYAOZqJeHPlxaxUpSmoECXaGfZolpghpvt6Bis17XJg==",
+      "license": "MIT",
+      "dependencies": {
+        "date-fns": "^3.6.0",
+        "moment": "^2.30.1",
+        "moment-hijri": "^2.30.0",
+        "vue": "^3.5.1"
+      }
+    },
+    "node_modules/vue-hijri-picker/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/vue-hijri-picker/node_modules/moment-hijri": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/moment-hijri/-/moment-hijri-2.30.0.tgz",
+      "integrity": "sha512-A3Ss8ASkhkT160laK9gXv+Yle0jA6eg92o8Uw78mU3OlUyaWjW2ntMd04kutawFb01KR0GIeJ8lqgIABGbWj7g==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.30.1"
       }
     },
     "node_modules/vue-i18n": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "numeral": "^2.0.6",
     "pinia": "^3.0.1",
     "vue": "^3.5.13",
+    "vue-hijri-picker": "^1.0.5",
     "vue-i18n": "^9.9.0",
     "vue-router": "^4.5.0"
   },

--- a/src/components/HijriDatePicker.vue
+++ b/src/components/HijriDatePicker.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, watch } from 'vue'
-import VueDatePicker from '@vuepic/vue-datepicker'
-import '@vuepic/vue-datepicker/dist/main.css'
+import DatePicker from 'vue-hijri-picker'
+import 'vue-hijri-picker/dist/style.css'
 import moment from 'moment-hijri'
 
 const props = defineProps({
@@ -13,31 +13,31 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue'])
 
-const innerValue = ref(null)
+const innerValue = ref('')
 
 watch(
   () => props.modelValue,
   (val) => {
-    innerValue.value = val ? moment(val, 'iYYYY-iMM-iDD').toDate() : null
+    innerValue.value = val ? moment(val, 'iYYYY-iMM-iDD').toISOString() : ''
   },
   { immediate: true },
 )
 
-watch(
-  innerValue,
-  (val) => {
-    if (val) {
-      emit('update:modelValue', moment(val).format('iYYYY-iMM-iDD'))
-    } else {
-      emit('update:modelValue', '')
-    }
-  },
-)
+watch(innerValue, (val) => {
+  if (val) {
+    emit('update:modelValue', moment(val).format('iYYYY-iMM-iDD'))
+  } else {
+    emit('update:modelValue', '')
+  }
+})
 </script>
 
 <template>
-  <VueDatePicker
+  <DatePicker
     v-model="innerValue"
+    initialType="hijri"
+    language="ar"
+    format="iYYYY-iMM-iDD"
     :input-class="'px-3 py-2 h-12 w-full border rounded-sm bg-white dark:bg-slate-800 focus:ring-3 focus:outline-hidden'"
   />
 </template>


### PR DESCRIPTION
## Summary
- add `vue-hijri-picker` dependency
- rewrite HijriDatePicker component to use the library and emit Hijri formatted strings
- keep DriverCardWorkflow watcher that adds one Hijri year

## Testing
- `npm run lint`
- `npm run format`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688536f4614c83318dc7179c4eeace49